### PR TITLE
The Angel Serivce

### DIFF
--- a/.src/managers/database_manager.py
+++ b/.src/managers/database_manager.py
@@ -70,8 +70,6 @@ class DatabaseManager:
             if not all(exists.values()):
                 print(f'Downloading {self._get_jar_name(driver)}')
                 download_errors[(self._get_jar_name(driver), '')] = self.dlm.download(driver)
-            # else:
-                # print(f'{self._get_jar_name(driver)} already exists. Skipping download.')
 
         self._distribute_drivers(exists_dict)
         return download_errors

--- a/.src/managers/download_manager.py
+++ b/.src/managers/download_manager.py
@@ -35,16 +35,23 @@ class DownloadManager:
     def _get_md5sum(self, url: str) -> str:
         return self.sysi.run_get_stdout(f'curl -L --progress-bar -u {self.username}:{self.password} {url} | md5sum | cut -d " " -f 1')
 
-    def validate_download(self, url: str) -> bool:
+    def _validate_download(self, url: str) -> bool:
         """Check the md5sum of the downloaded file against the one that would be downloaded
 
-        TODO: currently this doesn't work due to item location not being in the root where the script is
-        there is a file not found error.
+        Args:
+            url:
+                The url to download the file from.
+
+        Returns:
+            True if the md5sums do not match, False otherwise.
         
         """
         artifact = url.split("/")[-1]
         print(f'Validating {artifact}')
-        return self.sysi.run_get_stdout(f'md5sum {artifact} | cut -d " " -f 1') != self._get_md5sum(url)
+        return not self.check_md5sum(artifact, url)
+
+    def check_md5sum(self, artifact_path: str, artifact_url: str) -> bool:
+        return self.sysi.run_get_stdout(f'md5sum {artifact_path} | cut -d " " -f 1') == self._get_md5sum(artifact_url)
 
     def download(self, url: str) -> bool:
         """Download a file from a given url using wget or curl.
@@ -68,3 +75,4 @@ class DownloadManager:
             if cmd != 0:
                 return True
         return False
+        # return not self._validate_download(url)

--- a/.src/managers/node_manager.py
+++ b/.src/managers/node_manager.py
@@ -13,8 +13,10 @@ class NodeManager:
     """Deployment manager for handling a node deployments within CENM.
 
     Args:
-        services:
-            A list of services to deploy.
+        node:
+            The base node used, to create new nodes
+        node_count:
+            The number of nodes to deploy
 
     """
     def __init__(self, node: NodeDeploymentService, node_count: int):
@@ -67,7 +69,7 @@ class NodeManager:
     def _wait_for_service_termination(self):
             def _get_processes() -> int:
                 return int(self.sysi.run_get_stdout(
-                    'ps | grep -E ".*(cd cenm-node-.+\&\& java -jar).+(\.jar).+(\.conf).*" | wc -l | sed -e "s/^ *//g"'
+                    'ps | grep -E ".*(cd cenm-node-[0-9]+ \&\& java -jar).+(\.jar).+(\.conf).*" | wc -l | sed -e "s/^ *//g"'
                 ))
 
             java_processes = _get_processes()

--- a/.src/managers/service_manager.py
+++ b/.src/managers/service_manager.py
@@ -46,7 +46,8 @@ class ServiceManager:
         cenm_version: str,
         nms_visual_version: str,
         corda_version: str,
-        node_count: int
+        node_count: int,
+        deploy_without_angel: bool
     ):
         self.base_url = Constants.BASE_URL.value
         self.ext_package = Constants.EXT_PACKAGE.value
@@ -56,6 +57,7 @@ class ServiceManager:
         self.repos = Constants.REPOS.value
         self.db_services = Constants.DB_SERVICES.value
         self.node_count = node_count
+        self.deploy_without_angel = deploy_without_angel
         self.sysi = SystemInteract()
         self.printer = Printer(
             cenm_version,
@@ -64,6 +66,10 @@ class ServiceManager:
             nms_visual_version,
             corda_version
         )
+        if deploy_without_angel:
+            self.deploy_time = DeployTimeConstants
+        else:
+            self.deploy_time = DeployTimeAngelConstants
 
         self.AUTH = AuthService(
             abb=            'auth',
@@ -75,7 +81,7 @@ class ServiceManager:
             username=       username,
             password=       password,
             config_file=    'auth.conf',
-            deployment_time=Constants.AUTH_DEPLOY_TIME.value,
+            deployment_time=self.deploy_time.AUTH_DEPLOY_TIME.value,
             certificates=   2)
         self.CLIENT = AuthClientService(
             abb=            'client',
@@ -105,7 +111,7 @@ class ServiceManager:
             username=       username,
             password=       password,
             config_file=    'gateway.conf',
-            deployment_time=Constants.GATEWAY_DEPLOY_TIME.value,
+            deployment_time=self.deploy_time.GATEWAY_DEPLOY_TIME.value,
             certificates=   4)
         self.GATEWAY_PLUGIN = GatewayPluginService(
             abb=            'gateway-plugin',
@@ -134,8 +140,20 @@ class ServiceManager:
             url=            f'{self.base_url}/{self.enm_package}/services',
             username=       username,
             password=       password,
-            config_file=    'identitymanager.conf',
-            deployment_time=Constants.IDMAN_DEPLOY_TIME.value,
+            config_file=    'identitymanager-init.conf',
+            deployment_time=self.deploy_time.IDMAN_DEPLOY_TIME.value,
+            certificates=   3)
+        self.IDMAN_ANGEL = IdentityManagerAngelService(
+            abb=            'idman-angel',
+            dir=            'idman',
+            artifact_name=  'angel',
+            version=        cenm_version,
+            ext=            'zip',
+            url=            f'{self.base_url}/{self.enm_package}/services',
+            username=       username,
+            password=       password,
+            config_file=    'identitymanager-init.conf',
+            deployment_time=self.deploy_time.ANGEL_DEPLOY_TIME.value,
             certificates=   3)
         self.CRR_TOOL = CrrToolService(
             abb=            'crr-tool',
@@ -155,8 +173,20 @@ class ServiceManager:
             url=            f'{self.base_url}/{self.enm_package}/services',
             username=       username,
             password=       password,
-            config_file=    'networkmap.conf',
-            deployment_time=Constants.NMAP_DEPLOY_TIME.value,
+            config_file=    'networkmap-init.conf',
+            deployment_time=self.deploy_time.NMAP_DEPLOY_TIME.value,
+            certificates=   4)
+        self.NMAP_ANGEL = NetworkMapAngelService(
+            abb=            'nmap-angel',
+            dir=            'nmap',
+            artifact_name=  'angel',
+            version=        cenm_version,
+            ext=            'zip',
+            url=            f'{self.base_url}/{self.enm_package}/services',
+            username=       username,
+            password=       password,
+            config_file=    'networkmap-init.conf',
+            deployment_time=self.deploy_time.ANGEL_DEPLOY_TIME.value,
             certificates=   4)
         self.NOTARY = NotaryService(
             abb=            'notary',
@@ -168,7 +198,7 @@ class ServiceManager:
             username=       username,
             password=       password,
             config_file=    'notary.conf',
-            deployment_time=Constants.NODE_DEPLOY_TIME.value)
+            deployment_time=self.deploy_time.NOTARY_DEPLOY_TIME.value)
         self.NODE = NodeService(
             abb=            'node',
             dir=            'node',
@@ -179,7 +209,7 @@ class ServiceManager:
             username=       username,
             password=       password,
             config_file=    'node.conf',
-            deployment_time=Constants.NODE_DEPLOY_TIME.value)
+            deployment_time=self.deploy_time.NODE_DEPLOY_TIME.value)
         self.FINANCE_CONTRACTS_CORDAPP = FinanceContractsCordapp(
             abb=            'finance-contracts',
             dir=            'node',
@@ -228,7 +258,7 @@ class ServiceManager:
             username=       username,
             password=       password,
             config_file=    'signer.conf',
-            deployment_time=Constants.SIGNER_DEPLOY_TIME.value,
+            deployment_time=self.deploy_time.SIGNER_DEPLOY_TIME.value,
             certificates=   6)
         self.SIGNER_CA_PLUGIN = SignerPluginCAService(
             abb=            'signer-ca-plugin',
@@ -258,12 +288,12 @@ class ServiceManager:
             username=       username,
             password=       password,
             config_file=    '',
-            deployment_time=Constants.ZONE_DEPLOY_TIME.value,
+            deployment_time=self.deploy_time.ZONE_DEPLOY_TIME.value,
             certificates=   2)
 
         self.db_manager = DatabaseManager(self.get_database_services(), DownloadManager(username, password))
         self.config_manager = ConfigManager()
-        self.deployment_manager = DeploymentManager(self.get_deployment_services())
+        self.deployment_manager = DeploymentManager(self.get_deployment_services(deploy_without_angel=deploy_without_angel))
 
     def _get_all_services(self) -> List[BaseService]:
         return [
@@ -274,8 +304,10 @@ class ServiceManager:
             self.GATEWAY_PLUGIN,
             self.CLI,
             self.IDMAN,
+            self.IDMAN_ANGEL,
             self.CRR_TOOL,
             self.NMAP,
+            self.NMAP_ANGEL,
             self.NOTARY,
             self.NODE,
             self.FINANCE_CONTRACTS_CORDAPP,
@@ -297,31 +329,53 @@ class ServiceManager:
                 return service
         raise ValueError(f'No service with name {name}')
 
-    def get_deployment_services(self, pure_cenm: bool = False) -> List[DeploymentService]:
+    def get_deployment_services(self, pure_cenm: bool = False, deploy_without_angel: bool = False) -> List[DeploymentService]:
         """These services are returned in order they should be deployed
 
         For default deployments: do not change the order
         
         """
         if pure_cenm:
-            return [
-                self.IDMAN,
-                self.SIGNER,
-                self.NMAP,
-                self.AUTH,
-                self.GATEWAY,
-                self.ZONE
-            ]
+            if deploy_without_angel:
+                return [
+                    self.IDMAN,
+                    self.SIGNER,
+                    self.NMAP,
+                    self.AUTH,
+                    self.GATEWAY,
+                    self.ZONE
+                ]
+            else:
+                return [
+                    self.AUTH,
+                    self.GATEWAY,
+                    self.ZONE,
+                    self.IDMAN_ANGEL,
+                    self.SIGNER,
+                    self.NMAP_ANGEL
+                ]
         else:
-            return [
-                self.IDMAN,
-                self.SIGNER,
-                self.NOTARY,
-                self.NMAP,
-                self.AUTH,
-                self.GATEWAY,
-                self.ZONE
-            ]
+            if deploy_without_angel:
+                return [
+                    self.IDMAN,
+                    self.SIGNER,
+                    self.NOTARY, # Notary is not part of pure_cenm
+                    self.NMAP,
+                    self.AUTH,
+                    self.GATEWAY,
+                    self.ZONE
+                ]
+            else:
+                # This is returned by default
+                return [
+                    self.AUTH,
+                    self.GATEWAY,
+                    self.ZONE,
+                    self.IDMAN_ANGEL,
+                    self.SIGNER,
+                    self.NOTARY, # Notary is not part of pure_cenm
+                    self.NMAP_ANGEL
+                ]
 
     def get_database_services(self) -> List[BaseService]:
         return [service for service in self._get_all_services() if service.abb in self.db_services]
@@ -336,63 +390,55 @@ class ServiceManager:
             raise ExceptionGroup("Combined service exceptions", exceptions)
 
     def download_all(self):
+        # deprecated
         download_errors = {}
         for service in self._get_all_services():
+            # deprecated
             download_errors[(f'{service.artifact_name}-{service.version}', service.dir)] = service.download()
-
-        download_errors_db = self.db_manager.download()
-        # self.printer.print_end_of_script_report(download_errors, download_errors_db)
-
-        # self._raise_exception_group(download_errors)
-        # self._raise_exception_group(download_errors_db)
         self.check_all()
 
     def check_all(self):
         check_errors = {}
         print("Validating services")
         for service in self._get_all_services():
-            # self.logger.info(f'validating {service.artifact_name} config')
             if (not service._check_presence()):
                 check_errors[(f'{service.artifact_name}-{service.version}', service.dir)] = service.dir
-                print(u'[\u274c] ' + f'{service.artifact_name}-{service.version}')
+                print(u'[\u274c] ' + f'{service.dir}/{service.artifact_name}-{service.version}')
             else:
-                print(u'[\u2705] ' + f'{service.artifact_name}-{service.version}')
+                print(u'[\u2705] ' + f'{service.dir}/{service.artifact_name}-{service.version}')
         self._raise_exception_group(check_errors)
         print("Validating complete")
-        # else:
-            # self.printer.print_end_of_check_report(check_errors)
 
     def download_specific(self, services: List[str]):
         print("Downloading individual artifacts does not work with any other arguments, script will exit after downloading.")
+        # deprecated
         download_errors = {}
         for service in services:
             try:
                 service = self.get_service(service)
+                # deprecated
                 download_errors[(f'{service.artifact_name}-{service.version}', service.dir)] = service.download()
             except ValueError as e:
+                # deprecated except: find a better way to handle this
                 print(e)
                 download_errors[service] = str(e)
-        download_errors_db = self.db_manager.download()
-        # self.printer.print_end_of_script_report(download_errors, download_errors_db)
-
-        # self._raise_exception_group(download_errors)
-        # self._raise_exception_group(download_errors_db)
         self.check_all()
 
     def deploy_all(self, health_check_frequency: int):
         self.check_all()
-        self.config_manager.validate(self.get_deployment_services())
-        self.PKI.validate_certificates(self.get_deployment_services(pure_cenm=True))
+        self.config_manager.validate(self.get_deployment_services(deploy_without_angel=self.deploy_without_angel))
+        self.PKI.validate_certificates(self.get_deployment_services(pure_cenm=True, deploy_without_angel=self.deploy_without_angel))
         self.deployment_manager.deploy_services(health_check_frequency)
 
     def deploy_nodes(self, health_check_frequency: int):
         node_manager = self._get_node_manager()
         self.config_manager.validate(node_manager.new_nodes)
+        self.PKI.validate_certificates(node_manager.new_nodes)
         node_manager.deploy_nodes(health_check_frequency)
 
     def generate_certificates(self):
         self.check_all()
-        self.config_manager.validate([*self.get_deployment_services(), self.NODE, self.PKI])
+        self.config_manager.validate([*self.get_deployment_services(deploy_without_angel=self.deploy_without_angel), self.NODE, self.PKI])
         self.PKI.deploy()
 
     def clean_all(self,
@@ -412,7 +458,7 @@ class ServiceManager:
             )
         else:
             self.sysi.remove(".logs/*", silent=True)
-            for service in [*self.get_deployment_services(), self.NODE, self.PKI]:
+            for service in [*self.get_deployment_services(deploy_without_angel=self.deploy_without_angel), self.NODE, self.PKI]:
                 if clean_deep:
                     service.clean_all()
                     continue
@@ -433,4 +479,5 @@ class ServiceManager:
             except ValueError as e:
                 print(e)
 
-        
+    def versions(self):
+        return self.printer.print_cenm_version()

--- a/.src/utils.py
+++ b/.src/utils.py
@@ -15,7 +15,7 @@ def deprecated(func):
     @functools.wraps(func)
     def new_func(*args, **kwargs):
         warnings.simplefilter('always', DeprecationWarning)  # turn off filter
-        warnings.warn("Call to deprecated function {}.".format(func.__name__),
+        warnings.warn("{} is deprecated.".format(func.__name__),
                       category=DeprecationWarning,
                       stacklevel=2)
         warnings.simplefilter('default', DeprecationWarning)  # reset filter
@@ -39,9 +39,12 @@ class Constants(Enum):
 
     RUNTIME_FILES = {
         'dirs': ["logs", "h2", "ssh", "shell-commands", "djvm", "artemis", "brokers", "additional-node-infos"],
-        'notary_files': ["process-id", "network-parameters", "nodekeystore.jks", "truststore.jks", "sslkeystore.jks", "certificate-request-id.txt"]
+        'notary_files': ["process-id", "network-parameters", "nodekeystore.jks", "truststore.jks", "sslkeystore.jks", "certificate-request-id.txt"],
+        'angel_files': ["network-parameters.conf", "network-parameters.conf_bak", "networkmap.conf", "networkmap.conf_bak", "identitymanager.conf", "identitymanager.conf_bak", "token"]
     }
 
+class DeployTimeConstants(Enum):
+    ANGEL_DEPLOY_TIME = 5
     IDMAN_DEPLOY_TIME = 10
     SIGNER_DEPLOY_TIME = 10
     NMAP_DEPLOY_TIME = 20
@@ -49,22 +52,30 @@ class Constants(Enum):
     GATEWAY_DEPLOY_TIME = 5
     ZONE_DEPLOY_TIME = 10
 
+    NOTARY_DEPLOY_TIME = 60
     NODE_DEPLOY_TIME = 70
-    
 
+class DeployTimeAngelConstants(Enum):
+    ANGEL_DEPLOY_TIME = 5
+    IDMAN_DEPLOY_TIME = 30
+    SIGNER_DEPLOY_TIME = 10
+    NMAP_DEPLOY_TIME = 20
+    AUTH_DEPLOY_TIME = 15
+    GATEWAY_DEPLOY_TIME = 5
+    ZONE_DEPLOY_TIME = 10
+
+    NOTARY_DEPLOY_TIME = 5
+    NODE_DEPLOY_TIME = 30
+    
+# TODO: Logger needs an overhaul
 class Logger:
     """Logger management
 
-    Args:
-        name:
-            The name of the class that called the logger.
-
     """
     def __init__(self):
-        # self.name = name
         self.formatter = logging.Formatter('[%(asctime)s, %(levelname)s] %(name)s %(message)s')
 
-    def _set_logging_config(self, logger_name, log_file, level=logging.DEBUG):
+    def _set_logging_config(self, logger_name: str, log_file: str, level=logging.DEBUG):
         logger = logging.getLogger(logger_name)
 
         fileHandler = logging.FileHandler(log_file, mode='w')
@@ -77,38 +88,23 @@ class Logger:
         logger.addHandler(fileHandler)
         logger.addHandler(streamHandler)
 
-    def get_logger(self, name):
+    def get_logger(self, name: str):
         """Create a logger
 
+        Args:
+            name:
+                The name of the class that called the logger.
+
         Returns:
-            Returns a logger object with the name of the class that called it.
+            A logger object with the name of the class that called it.
 
         """
-        # handler = logging.FileHandler(f".logs/default-deployment-{self.name}.log")
-        # handler.setFormatter(self.formatter)
-        # # logging.basicConfig(
-        # #     filename=f".logs/default-deployment-{self.name}.log",
-        # #     filemode='a',
-        # #     format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
-        # #     datefmt='%H:%M:%S',
-        # #     level=logging.DEBUG
-        # # )
-        # logger = logging.getLogger(self.name)
-        # logger.setLevel(logging.DEBUG)
-        # logger.addHandler(handler)
-        # print(os.getcwd())
         self._set_logging_config(name, f".logs/default-deployment-{name}.log")
         return logging.getLogger(name)
-        # return logging.getLogger(self.name)
-        # return logger
-        # print(f'creating logger with name: {self.name}')
-        # return logging.getLogger(self.name)
 
+# TODO: Printer can probably be absorbed into [ServiceManager]
 class Printer:
-    """Printer for standard printing
-
-    Deprecated class: use ExceptionGroup in favour.
-    other print statements can be done inline in class
+    """Printer for version printing
 
     """
     def __init__(self,
@@ -124,10 +120,9 @@ class Printer:
         self.nms_visual_version = nms_visual_version
         self.corda_version = corda_version
 
-    @deprecated
     def print_cenm_version(self):
         print("""
-Cenm local deployment manager
+CENM local deployment manager
 =====================================
 
 Current CENM version:    {}
@@ -136,7 +131,6 @@ Current Gateway version: {}
 Current NMS version:     {}
 
 Current Corda version:   {}
-
         """.format(
             self.cenm_version,
             self.auth_version,
@@ -145,83 +139,133 @@ Current Corda version:   {}
             self.corda_version
         ))
 
-    @deprecated
-    def print_deployment_complete(self):
-        print("""
-Deployment complete
-=====================================
-
-Deployment logs can be found under: .logs/default-deployment.log
-
-        """)
-
-    @deprecated
-    def print_end_of_script_report(self, download_errors, download_errors_db):
-        print("""
-End of script report
-=====================================
-        """)
-        if any(download_errors.values()):
-            print("The following errors were encountered when downloading artifacts:")
-            for artifact_name, error in download_errors.items():
-                if error:
-                    print(f'Error encountered when downloading {artifact_name}, please check version and try again.')
-        else:
-            print("All artifacts downloaded successfully.")
-        if any(download_errors_db.values()):
-            print("The following errors were encountered when downloading database drivers:")
-            for artifact_name, error in download_errors_db.items():
-                if error:
-                    print(f'Error encountered when downloading {artifact_name}, please check version and try again.')
-        else:
-            print("All database drivers downloaded successfully.")
-
-    @deprecated
-    def print_end_of_check_report(self, check_errors):
-        print("""
-End of validation report
-=====================================
-        """)
-        if any(check_errors.values()):
-            print("The following errors were encountered when validating artifacts:")
-            for artifact_name, error in check_errors.items():
-                if error:
-                    print(f'Failed to validate {artifact_name}, artifact not found.')
-        else:
-            print("All artifacts validated successfully.")
-
 class SystemInteract:
     """Class for using system commands
 
     """
-    def path_exists(self, path) -> bool:
+    def path_exists(self, path: str) -> bool:
+        """Checks a path exists
+
+        Args:
+            path:
+                A path to check.
+
+        Returns:
+            True if path exists False if not.
+
+        """
         return os.path.exists(path)
 
-    def sleep(self, seconds):
+    def sleep(self, seconds: int):
+        """Sends sleep command to system, not python sleep
+
+        Args:
+            seconds:
+                Number of seconds to sleep.
+
+        """
         os.system(f'sleep {seconds}')
 
-    def perl(self, file, predicate, replace, multi_line: bool = False):
+    def perl(self, file: str, predicate: str, replace: str, multi_line: bool = False):
+        """Runs a perl replacement command
+
+        Args:
+            file:
+                The file on which to perform the replacement.
+            predicate:
+                The string to replace.
+            replace:
+                The string to replace with.
+            multi_line:
+                If true, will ingest the whole file to perform multi-line replacements.
+
+        """
         if multi_line:
             os.system(f'perl -0777 -i -pe "s/{predicate}/{replace}/" {file}')
         else:
             os.system(f'perl -i -pe "s/{predicate}/{replace}/" {file}')
 
-    def remove(self, path, silent: bool = False):
+    def remove(self, path: str, silent: bool = False):
+        """Removes a system path
+
+        Args:
+            path:
+                A path to remove (works for both folders and files).
+            silent:
+                If true, will suppress output.
+
+        """
         if silent:
             os.system(f'rm -rf {path} > /dev/null 2>&1')
         else:
             os.system(f'rm -rf {path}')
 
-    def run(self, cmd):
+    def create_file_with(self, path: str, content: str):
+        """Creates a file with content
+
+        Args:
+            path:
+                A path to create.
+            content:
+                The content to write to the file.
+
+        """
+        os.system(f'echo "{content}" > {path}')
+
+    def file_contains(self, path: str, content: str) -> bool:
+        """Checks if a file contains a string
+
+        Args:
+            path:
+                A path to check.
+            content:
+                The content to check for.
+
+        Returns:
+            True if the file contains the string, False otherwise.
+
+        """
+        return os.system(f'grep -q "{content}" {path}') == 0
+
+    def run(self, cmd: str):
+        """Runs a system command
+
+        Args:
+            cmd:
+                Command to run.
+
+        """
         os.system(cmd)
 
-    def run_get_exit_code(self, cmd, silent: bool = False) -> int:
+    def run_get_exit_code(self, cmd: str, silent: bool = False) -> int:
+        """Runs a system command and returns the exit code
+
+        Args:
+            cmd:
+                Command to run.
+            silent:
+                If true, will suppress output.
+
+        Returns:
+            The exit code of the command.
+
+        """
         if silent:
             return os.system(f'{cmd} > /dev/null 2>&1')
         else:
             return os.system(cmd)
 
-    def run_get_stdout(self, cmd) -> str:
+    def run_get_stdout(self, cmd: str) -> str:
+        """Runs a system command and returns the stdout stream
+
+        Args:
+            cmd:
+                Command to run.
+
+        Returns:
+            The stdout stream as a string.
+
+        """
         unique_file = f'.tmp-{uuid.uuid4().hex}'
         os.system(f'{cmd} > {unique_file}')
         try:
@@ -230,7 +274,23 @@ class SystemInteract:
             self.remove(unique_file, silent=True)
         except:
             out = 'E: Could not read stdout'
+            self.remove(unique_file, silent=True)
         return out
+    
+    def wait_for_host_on_port(self, port: int, host: str = "localhost"):
+        """Waits for a host to be available on a port
+
+        Args:
+            port:
+                The port to wait on.
+            host:
+                The host to wait on, default is localhost.
+
+        """
+        while self.run_get_exit_code(f'timeout 5 ncat -z {host} {port}') != 0:
+            self.sleep(5)
+        # Safety sleep to allow service on [port] to fully start
+        self.sleep(10)
 
 class CenmTool:
     """Class for using cenm cli tool
@@ -297,26 +357,32 @@ class CenmTool:
         tokens = {}
 
         self.set_admin_address('identity-manager', 'localhost:5053')
-        # print(self.sysi.run_get_stdout(f'(cd {self.path} && cat ../../cenm-idman/identitymanager.conf)'))
-        tokens['idman'] = self.set_config('identity-manager', '../../cenm-idman/identitymanager.conf')
-        
-        self.set_admin_address('netmap', 'localhost:5055')
-        # print(self.sysi.run_get_stdout(f'(cd {self.path} && cat ../../cenm-nmap/networkparameters.conf)'))
+        # print(self.sysi.run_get_stdout(f'(cd {self.path} && cat ../../cenm-idman/identitymanager-init.conf)'))
+        tokens['idman'] = self.set_config('identity-manager', '../../cenm-idman/identitymanager-init.conf')
+
+        self.sysi.create_file_with(f'cenm-idman/token', tokens['idman'])
+
+        while not self.sysi.file_contains("cenm-nmap/network-parameters-init.conf", "notaryNodeInfoFile.*nodeInfo"):
+            self.sysi.sleep(5)
+
+        # print(self.sysi.run_get_stdout(f'(cd {self.path} && cat ../../cenm-nmap/network-parameters-init.conf)'))
         tokens['nmap'] = self.create_zone(
-            config_file='../../cenm-nmap/networkmap.conf',
+            config_file='../../cenm-nmap/networkmap-init.conf',
             network_map_address='localhost:20000',
-            network_parameters='../../cenm-nmap/networkparameters.conf',
+            network_parameters='../../cenm-nmap/network-parameters-init.conf',
             label='Main',
             label_color='#941213'
         )
         self.set_admin_address('signer', 'localhost:5054')
         # print(self.sysi.run_get_stdout(f'(cd {self.path} && cat ../../cenm-signer/signer.conf)'))
         tokens['signer'] = self.set_config('signer', '../../cenm-signer/signer.conf')
+
+        for token_dir, token in tokens.items():
+            if not self.sysi.path_exists(f'cenm-{token_dir}/token'):
+                self.sysi.create_file_with(f'cenm-{token_dir}/token', token)
+
         return tokens
 
     def cenm_set_subzone_config(self, subzone: str) -> str:
-        # necessary step?
-        self.set_admin_address('identity-manager', 'localhost:5053', subzone=subzone)
         self.set_admin_address('netmap', 'localhost:5055', subzone=subzone)
-
-        return self.set_config('netmap', '../../cenm-nmap/networkmap.conf', subzone=subzone)
+        return self.set_config('netmap', '../../cenm-nmap/networkmap-init.conf', subzone=subzone)

--- a/README.md
+++ b/README.md
@@ -1,29 +1,17 @@
 # cenm-deployment-local
 
-This is a complete python framework for deploying an enterprise grade CENM deployment in a local environment for testing related purposes. This is the host repo to tie in separate CENM service config repos. Features of this framework include:
+This is a complete Python framework for deploying an enterprise grade CENM deployment in a local environment for testing related purposes. This is the host repo to tie in separate CENM service config repos. Features of this framework include:
 
 - Download CENM artifacts, including plugins, database drivers and Corda node CorDapps
 - Generating a CENM PKI and distributing certificates to all CENM services.
 - Quickly deploy and stop a complete CENM network
-
-## One line install (deprecated)
-
-> <font color="orange">&#9888; Deprecation warning: this installation script is no longer being updated, instead please refer to [One-line auto-deployment](#one-line-auto-deployment) for a quick automated setup process.</font>
-
-If you want to skip having to clone the repo manually and running the script yourself here is a one-line-installation script, you will be prompted to setup a `.env` file with your credentials and CENM versions. Then it will download all your artifacts and config files and run the certificate generation for your CENM services
-
-```shell
-/bin/bash -c "$(curl -fsSl https://raw.githubusercontent.com/tomstark99/cenm-deployment-local/HEAD/install.sh)"
-```
-
-You then skip to the [Deployment Order](#deployment-order) section
 
 ## Getting started
 
 1. Clone this repo locally:
 
     ```shell
-    git clone --branch=dev/tom https://github.com/tomstark99/cenm-deployment-local.git
+    git clone https://github.com/tomstark99/cenm-deployment-local.git
     ```
 
 2. Copy and rename the `.env.template` file to `.env`, here you will fill in your credentials
@@ -44,6 +32,8 @@ You then skip to the [Deployment Order](#deployment-order) section
     NOTARY_VERSION=<corda_version>
     ```
 
+    _Note: It is not recommended that you use a Corda version lower than 4.8.X these versions are no longer supported and might cause deployment problems._
+
 4. The `pyhocon` package is required for this script to work, install this in your python installation using
 
     > <font color="orange">&#9888; If you have more than one python installation then your default `pip` command may default to a different installation than your default `python` or `python3` command. If this is the case you may get errors that the `pyhocon` package still couldn't be found after installing it. Make sure you use the correct pip command for the python installation.</font>
@@ -57,22 +47,23 @@ You then skip to the [Deployment Order](#deployment-order) section
     ```
     $ python3 setup_script.py -h
     usage: setup_script.py [-h]
-                        [--setup-dir-structure]
-                        [--download-individual DOWNLOAD_INDIVIDUAL]
-                        [--generate-certs]
-                        [--run-default-deployment]
-                        [--run-node-deployment RUN_NODE_DEPLOYMENT]
-                        [--nodes]
-                        [--clean-runtime]
-                        [--clean-certs]
-                        [--clean-artifacts]
-                        [--deep-clean]
-                        [--clean-individual-artifacts CLEAN_INDIVIDUAL_ARTIFACTS]
-                        [--health-check-frequency HEALTH_CHECK_FREQUENCY]
-                        [--validate]
-                        [--version]
+                           [--setup-dir-structure]
+                           [--download-individual DOWNLOAD_INDIVIDUAL]
+                           [--generate-certs]
+                           [--run-default-deployment]
+                           [--run-node-deployment RUN_NODE_DEPLOYMENT]
+                           [--deploy-without-angel]
+                           [--nodes]
+                           [--clean-runtime]
+                           [--clean-certs]
+                           [--clean-artifacts]
+                           [--deep-clean]
+                           [--clean-individual-artifacts CLEAN_INDIVIDUAL_ARTIFACTS]
+                           [--health-check-frequency HEALTH_CHECK_FREQUENCY]
+                           [--validate]
+                           [--version]
 
-    Download CENM artifacts from Artifactory
+    A modular framework for local CENM deployments and testing.
 
     options:
     -h, --help            show this help message and exit
@@ -86,6 +77,8 @@ You then skip to the [Deployment Order](#deployment-order) section
                             Runs a default deployment, following the steps from README
     --run-node-deployment RUN_NODE_DEPLOYMENT
                             Run node deployments for a given number of nodes
+    --deploy-without-angel
+                            Deploys services without the angel service
     --nodes               To be used together with clean arguments to specify cleaning for node directorie
     --clean-runtime       Remove all generated runtime files
     --clean-certs         Remove all generated certificates
@@ -102,7 +95,7 @@ You then skip to the [Deployment Order](#deployment-order) section
 
 ### Setup Directory Structure
 
-To set up your directory structure and certificates so that you can start your CENM deployment there are two commands in the script that can be run simultaneously
+To set up your directory structure and certificates so that you can start your CENM deployment there are two commands in the script that can be run simultaneously:
 
 ```shell
 python3 setup_script.py --setup-dir-structure --generate-certs
@@ -132,7 +125,7 @@ A health check runs on the subprocesses every 30 seconds and will restart servic
 
 ### CENM Environment Re-deployment
 
-Sometimes you may have missed something in your config or setup and need to re-deploy, or you want to shut down your existing network, do some changes and then deploy again. This is all possible with the script.
+Sometimes you may have missed something in your config or setup and need to re-deploy, or you want to shut down your existing network, do some changes and then deploy again.
 
 You can stop a running CENM deployment with a keyboard interrupt `Ctrl+C`, this will gracefully stop all services and shutdown your network. If you then want to start the **same** network again with the same databases and registered nodes, you can do this by running:
 
@@ -153,81 +146,8 @@ CENM services should be deployed in a particular order, this being:
     ```
     
     This will run the pki tool and copy the generated certificates into the correct locations for each service
-    
-2. Start the identity manager
 
-    ```shell
-    java -jar identitymanager.jar -f identitymanager.conf
-    ```
-    
-3. Start the signer service
-
-    ```shell
-    java -jar signer.jar -f signer.conf
-    ```
-    
-4. Register the notary
-
-    ```shell
-    java -jar corda.jar \
-        -f notary.conf
-        --initial-registration \ # Depending on the Corda version
-        --network-root-truststore ./certificates/network-root-truststore.jks \
-        --network-root-truststore-password trustpass
-    ```
-    
-    _Note: There is currently a known issue (https://github.com/tomstark99/cenm-deployment-local/issues/5) where corda version of `4.5.X` might cause exceptions during registration._
-    
-5. Update the `networkparameters.conf` file with the correct `nodeInfo`
-
-    When the notary is registered with the network it generates a `nodeInfo-XXXXX...` file. The name of this file needs to replace the `INSERT_NODE_INFO_FILE_NAME_HERE` placeholder in the `cenm-nmap/networkparameters.conf` file e.g.
-    
-    ```properties
-    notaries : [
-        {
-            notaryNodeInfoFile: "nodeInfo-DFD4D403F65EA6C9B33B653A8B855CB3C4F04D599B373E662EBD2146241219F2"
-            validating = false
-        }
-    ]
-
-    minimumPlatformVersion = 4
-    maxMessageSize = 10485760
-    maxTransactionSize = 10485760
-    eventHorizonDays = 10 # Duration in days
-    ```
-    
-    The `nodeInfo-XXXXX...` file should also be copied to the `cenm-nmap/` folder
-    
-    ```shell
-    cp cenm-notary/nodeInfo-* cenm-nmap/
-    ```
-    
-6. Set network parameters
-
-    ```shell
-    java -jar networkmap.jar \
-        -f networkmap.conf \
-        --set-network-parameters networkparameters.conf \
-        --network-truststore ./certificates/network-root-truststore.jks \
-        --truststore-password trustpass \
-        --root-alias cordarootca
-    ```
-    
-7. Start the network map
-
-    ```shell
-    java -jar networkmap.jar -f networkmap.conf
-    ```
-    
-8. Start the notary
-
-    ```shell
-    java -jar corda.jar -f notary.conf
-    ```
-    
-    _Note: you may have to wait while the network parameters that were set in step 5 are signed, this can take a few minutes._
-
-9. Start the auth service
+2. Start the auth service
 
     ```shell
     java -jar accounts-application.jar \
@@ -238,17 +158,15 @@ CENM services should be deployed in a particular order, this being:
         --verbose
     ```
     
-10. Start the private gateway service
+3. Start the private gateway service
 
     ```shell
     java -jar gateway-service.jar -f private.conf
     ```
-    
-    
 
-    > <font color="orange">&#9888; The public gateway service is optional and is not covered in the setup for this deployment. The public gateway service is intended for a real-world deployment  where you want a general gateway access for network users since it doesn't include the user admin control options.
+    > <font color="orange">&#9888; The public gateway service is optional and is not covered in the setup for this deployment. The public gateway service is intended for a real-world deployment where you want to provide gateway access for standard network users which doesn't include the user admin control options.
     > 
-    > Step 12-15 of this guide are focused on auth/gateway setup where, for the purpose of this deployment only the private gateway is configured. The private gateway has all the functionality of the public one so unless you are doing specific public gateway testing it is recommended you ignore it.</font>
+    > Step 6-9 of this guide are focused on auth/gateway setup where, for the purpose of this deployment only the private gateway is configured. The private gateway has all the functionality of the public one so unless you are doing specific public gateway testing it is recommended you ignore it.</font>
 
     You can deploy the public gateway in the same way as the private gateway:
 
@@ -256,7 +174,7 @@ CENM services should be deployed in a particular order, this being:
     java -jar gateway-service.jar -f public.conf
     ```
     
-11. Start the zone service
+4. Start the zone service
 
     ```shell
     java -jar zone.jar \
@@ -281,9 +199,9 @@ CENM services should be deployed in a particular order, this being:
         --tls-truststore-password=trustpass
     ```
 
-12. Verify your gateway is up by navigating to http://localhost:8089
+5. Verify your gateway is up by navigating to http://localhost:8089 where you should see a login screen.
 
-13. Run setupAuth initially to create users in the global zone:
+6. Run setupAuth initially to create users in the global zone:
 
     ```shell
     cd cenm-auth/setup-auth
@@ -292,7 +210,7 @@ CENM services should be deployed in a particular order, this being:
 
     _Note: this script requires [jq](https://stedolan.github.io/jq/download/), a command line JSON processor that can be installed easily in various ways._
 
-14. Create a 'Main' subzone
+7. Set the identity manager config using the CENM CLI-tool
 
     Navigate to the cenm-tool directory
 
@@ -300,14 +218,96 @@ CENM services should be deployed in a particular order, this being:
     cd cenm-gateway/cenm-tool
     ```
 
-    First set your global zone config for identity manager and network map:
+    First set your global zone config for identity manager:
 
     ```shell
     ./cenm context login -s http://127.0.0.1:8089 -u config-maintainer -p <password>
     ./cenm identity-manager config set-admin-address -a=127.0.0.1:5053
-    ./cenm identity-manager config set -f=identitymanager.conf --zone-token
-    ./cenm netmap config set-admin-address -a=127.0.0.1:5053
+    ./cenm identity-manager config set -f=identitymanager-init.conf --zone-token
     ./cenm context logout http://127.0.0.1:8089
+    ```
+
+    _Note: Make a note of the token returned from the `--zone-token` command it is needed for the next step._
+
+8. Start the Angel service for `IDENTITY_MANAGER`
+
+    Using the zone token generated from the step above, start the Angel service for the Identity Manager.
+
+    ```shell
+    java -jar angel.jar \
+        --jar-name=identitymanager.jar \
+        --zone-host=127.0.0.1 \
+        --zone-port=5061 \
+        --token=<idman-zone-token> \
+        --service=IDENTITY_MANAGER \
+        --polling-interval=10 \
+        --working-dir=./ \
+        --tls=true \
+        --tls-keystore=./certificates/corda-ssl-identity-manager-keys.jks \
+        --tls-keystore-password=password \
+        --tls-truststore=./certificates/corda-ssl-trust-store.jks \
+        --tls-truststore-password=trustpass \
+        --verbose
+    ```
+    
+9. Start the signer service
+
+    ```shell
+    java -jar signer.jar -f signer.conf
+    ```
+
+    _Note: While the Signer can also be deployed using the Angel service this is not the default behavior of the CENM helm chat deployment and therefore is not covered in this guide._
+
+10. Register the notary
+
+    ```shell
+    java -jar corda.jar initial-registration \
+        -f notary.conf
+        --network-root-truststore ./certificates/network-root-truststore.jks \
+        --network-root-truststore-password trustpass
+    ```
+    
+11. Update the `network-parameters-init.conf` file with the correct `nodeInfo`
+
+    When the notary is registered with the network it generates a `nodeInfo-XXXXX...` file. The name of this file needs to replace the `INSERT_NODE_INFO_FILE_NAME_HERE` placeholder in the `cenm-nmap/network-parameters-init.conf` file e.g.
+    
+    ```properties
+    notaries : [
+        {
+            notaryNodeInfoFile: "nodeInfo-DFD4D403F65EA6C9B33B653A8B855CB3C4F04D599B373E662EBD2146241219F2"
+            validating = false
+        }
+    ]
+
+    minimumPlatformVersion = 4
+    maxMessageSize = 10485760
+    maxTransactionSize = 10485760
+    eventHorizonDays = 10 # Duration in days
+    ```
+    
+    The `nodeInfo-XXXXX...` file should also be copied to the `cenm-nmap/` folder
+    
+    ```shell
+    cp cenm-notary/nodeInfo-* cenm-nmap/
+    ```
+    
+12. Set network parameters
+
+    ```shell
+    java -jar networkmap.jar \
+        -f networkmap-init.conf \
+        --set-network-parameters network-parameters-init.conf \
+        --network-truststore ./certificates/network-root-truststore.jks \
+        --truststore-password trustpass \
+        --root-alias cordarootca
+    ```
+
+13. Create a 'Main' subzone
+
+    Navigate to the cenm-tool directory
+
+    ```shell
+    cd cenm-gateway/cenm-tool
     ```
 
     To create a subzone, you need the `network-maintainer` login:
@@ -315,9 +315,9 @@ CENM services should be deployed in a particular order, this being:
     ```shell
     ./cenm context login -s http://127.0.0.1:8089 -u network-maintainer -p <password>
     ./cenm zone create-subzone \
-        --config-file=../../cenm-nmap/networkmap.conf \
+        --config-file=../../cenm-nmap/networkmap-init.conf \
         --network-map-address=127.0.0.1:20000 \
-        --network-parameters=../../cenm-nmap/networkparameters.conf \
+        --network-parameters=../../cenm-nmap/network-parameters-init.conf \
         --label=Main \
         --label-color='#941213' \
         --zone-token
@@ -343,34 +343,52 @@ CENM services should be deployed in a particular order, this being:
     Set your network map config for the subzone and replace the `<SUBZONE_ID>` with the id returned from:
 
     ```shell
-    ./cenm netmap config set -s <SUBZONE_ID> -f=networkmap.conf
+    ./cenm netmap config set -s <SUBZONE_ID> -f=networkmap-init.conf
     ./cenm context logout http://127.0.0.1:8089
     ```
+    
+    
+14. Start the Angel service for `NETWORK_MAP`
 
-<!-- 15. Set your zone config
-
-    Set the 'Main' zone config to be the same as the global zone, for this you will need the `config-maintainer` login
+    Using the zone token generated from the step above, start the Angel service for the Network Map.
 
     ```shell
-    ./cenm context login -s http://127.0.0.1:8089 -u config-maintainer -p <password>
-    ./cenm identity-manager config set \
-        --config-file=../../cenm-idman/identitymanager.conf \
-        --zone-token
-    ./cenm signer config set \
-        --config-file=../../cenm-signer/signer.conf \
-        --zone-token
+    java -jar angel.jar \
+    --jar-name=networkmap.jar \
+    --zone-host=127.0.0.1 \
+    --zone-port=5061 \
+    --token=<nmap-zone-token> \
+    --service=NETWORK_MAP \
+    --polling-interval=10 \
+    --working-dir=./ \
+    --network-truststore=./certificates/network-root-truststore.jks \
+    --truststore-password=trustpass \
+    --root-alias=cordarootca \
+    --network-parameters-file=network-parameters.conf \
+    --tls=true \
+    --tls-keystore=./certificates/corda-ssl-network-map-keys.jks \
+    --tls-keystore-password=password \
+    --tls-truststore=./certificates/corda-ssl-trust-store.jks \
+    --tls-truststore-password=trustpass \
+    --verbose
     ```
-
-    Again, make a note of the zone token that is returned in case you need it later (for example if you are using the angel service) -->
     
-15. To grant your users access to the new subzone, replace the `<SUBZONE_ID>` with the id returned from
+15. Start the notary
+
+    ```shell
+    java -jar corda.jar -f notary.conf
+    ```
+    
+    _Note: you may have to wait while the network parameters that were set in step 5 are signed, this can take a few minutes._
+    
+16. To grant your users access to the new subzone, replace the `<SUBZONE_ID>` with the id returned from this command:
 
     ```shell
     ./cenm context login -s http://127.0.0.1:8089 -u config-maintainer -p <password>
     ./cenm zone get-subzones
     ```
 
-    The user roles are located in the cenm-auth directory, in the example below the zone id is `1` which should be substituted `"s//<here>/g"` in the `perl` command
+    The user roles are located in the cenm-auth directory, in the example below the zone id is `1` which should be substituted `"s//<here>/g"` in the `perl` command below:
 
     ```shell
     cd cenm-auth/setup-auth/roles

--- a/setup_script.py
+++ b/setup_script.py
@@ -8,7 +8,7 @@ from typing import Dict
 from managers.service_manager import ServiceManager
 from utils import SystemInteract
 
-parser = argparse.ArgumentParser(description='Download CENM artifacts from Artifactory')
+parser = argparse.ArgumentParser(description='A modular framework for local CENM deployments and testing.')
 parser.add_argument(
     '--setup-dir-structure', 
     default=False, 
@@ -37,6 +37,12 @@ parser.add_argument(
     default=0,
     type=int,
     help='Run node deployments for a given number of nodes'
+)
+parser.add_argument(
+    '--deploy-without-angel',
+    default=False, 
+    action='store_true',
+    help='Deploys services without the angel service'
 )
 parser.add_argument(
     '--nodes',
@@ -113,6 +119,21 @@ except KeyError as e:
     raise KeyError(f"Missing variable in .env file: {e}")
 
 def validate_arguments(args: argparse.Namespace):
+    # Check .env variables are not empty
+    if not username:
+        raise KeyError("ARTIFACTORY_USERNAME is empty")
+    if not password:
+        raise KeyError("ARTIFACTORY_API_KEY is empty")
+    if not auth_version:
+        raise KeyError("AUTH_VERSION is empty")
+    if not gateway_version:
+        raise KeyError("GATEWAY_VERSION is empty")
+    if not cenm_version:
+        raise KeyError("CENM_VERSION is empty")
+    if not nms_visual_version:
+        raise KeyError("NMS_VISUAL_VERSION is empty")
+    if not corda_version:
+        raise KeyError("NOTARY_VERSION is empty")
     # Check if only one of the clean flags are used
     clean_args = [args.clean_runtime, args.deep_clean, args.clean_artifacts, args.clean_certs]
     if sum(clean_args) > 1:
@@ -128,6 +149,7 @@ def validate_arguments(args: argparse.Namespace):
         args.clean_artifacts, 
         args.deep_clean, 
         args.run_default_deployment, 
+        args.deploy_without_angel,
         args.run_node_deployment,
         args.nodes,
         args.version, 
@@ -154,6 +176,8 @@ def validate_arguments(args: argparse.Namespace):
         raise ValueError("Please specify between 0 and 9 nodes")
     if args.run_default_deployment and args.run_node_deployment:
         raise ValueError("Please only run one deployment at a time")
+    if args.deploy_without_angel and not args.run_default_deployment:
+        raise ValueError("Cannot use --deploy-without-angel without --run-default-deployment")
     if args.run_default_deployment:
         if SystemInteract().run_get_exit_code("jq --help", silent=True) != 0:
             raise RuntimeError("jq is not installed in your shell, please install it and try again")
@@ -167,14 +191,11 @@ Your python installation is missing the:
     pyhocon
 
 package which is required for this script to run. Please install it using:
-    pip install pyhocon""")
+    python -m pip install pyhocon""")
 
 def main(args: argparse.Namespace):
 
     validate_arguments(args)
-
-    if args.version:
-        raise NotImplementedError("Version check is not implemented yet")
 
     service_manager = ServiceManager(
         username,
@@ -184,7 +205,8 @@ def main(args: argparse.Namespace):
         cenm_version,
         nms_visual_version,
         corda_version,
-        args.run_node_deployment
+        args.run_node_deployment,
+        args.deploy_without_angel
     )
 
     if args.download_individual:
@@ -202,6 +224,9 @@ def main(args: argparse.Namespace):
         args.clean_runtime,
         args.nodes
     )
+
+    if args.version:
+        service_manager.versions()
 
     if args.validate:
         service_manager.check_all()


### PR DESCRIPTION
Added angel service deploymens to the default CENM deployment to fully implement a complete test enterpise environment

## Changes

- Added angel service deployment for identity manager and network map

	This allows those services to work properly together with the auth zone and gateway services. Currently the network map angel service will only work if your network network root truststore path is not in a subpath of an absolute path that contains spaces due to how the angel service handles command line parameter splitting.

	You can also deploy CENM without the angel service using `--deploy-without-angel` however this is not recommended

- Added a check to raise an error for when variables in the env file are empty
- Implemented `--version` flag to print out current versions set in env file
- Removed lots of deprecated code
- Added service directory as a suffix to the deployment service name to help differentiate when more than one angel service manages different services
- Added framework for future possibility of verifying (existing) downloaded files against its *official* md5sum (will only work with artifactory api)
- Added certificate validation check for node deployments

## Fixes

- Removed a broken step where identity manager admin address was being set for a specific subzone during setup
- Fixed an issue where default deployment termination would hang if node deployment was also running
- Fixed an issue where default deployment termination would end with a nonzero exit code
- Fixed regex for node deployment temrination to only check for node dirs with a number suffix `cenm-node-[0-9]+`
- Zipped artifacts are now unzipped quietly