### PR TITLE
Small fixes

### DIFF
--- a/.src/services/base_services.py
+++ b/.src/services/base_services.py
@@ -242,6 +242,19 @@ class NodeDeploymentService(DeploymentService):
     def __repr__(self):
         return self.__str__()
 
+    def _notary(self) -> bool:
+        """Check if the [NodeDeploymentService] is a notary
+
+            Caution this only works for the default notary configured
+            in the [ServiceManager] from the hardcorded abb variable.
+
+            To implement this properly the [NodeDeploymentService] should
+            overload the __init__ method and pass in a notary boolean for
+            node services.
+
+        """
+        return self.abb == "notary"
+
     def _construct_new_node_dir(self, new_dir):
         self.sysi.run(f'cp -r {self.dir} cenm-{new_dir}')
         node_number = new_dir.split("-")[-1]
@@ -290,7 +303,8 @@ class NodeDeploymentService(DeploymentService):
             self._register_node(artifact_name)
             self.sysi.wait_for_host_on_port(20000)
             # wait for network parameters to be signed
-            self.sysi.sleep(90)
+            if self._notary():
+                self.sysi.sleep(90)
 
         while True:
             try:

--- a/.src/services/services.py
+++ b/.src/services/services.py
@@ -244,9 +244,6 @@ class NetworkMapAngelService(NetworkMapService):
             sleep(5)
 
         token = self.sysi.run_get_stdout(f'(cd {self.dir} && head -1 token)').strip()
-        # TODO: duplicated, remove before commit
-        print(f'Network Map token: {token}')
-        print(f'[Running] (cd {self.dir} && java -jar {self.artifact_name}.jar --jar-name=networkmap.jar --zone-host=127.0.0.1 --zone-port=5061 --token={token} --service=NETWORK_MAP --polling-interval=10 --working-dir=./ --network-truststore=./certificates/network-root-truststore.jks --truststore-password=trustpass --root-alias=cordarootca --network-parameters-file=network-parameters.conf --tls=true --tls-keystore=./certificates/corda-ssl-network-map-keys.jks --tls-keystore-password=password --tls-truststore=./certificates/corda-ssl-trust-store.jks --tls-truststore-password=trustpass --verbose)')
 
         while True:
             try:

--- a/.src/utils.py
+++ b/.src/utils.py
@@ -287,7 +287,7 @@ class SystemInteract:
                 The host to wait on, default is localhost.
 
         """
-        while self.run_get_exit_code(f'nc -z -G 3 {host} {port}') != 0:
+        while self.run_get_exit_code(f'nc -z -G 3 {host} {port} > /dev/null 2>&1') != 0:
             self.sleep(5)
         # Safety sleep to allow service on [port] to fully start
         self.sleep(10)


### PR DESCRIPTION
- Added `node._notary() -> bool` to fix an issue where nodes start would be delayed by 90 seconds to allow network parameters to be signed. This delay is only needed for the notary.
- suppressed stdout for netcat port check in utils
- removed some print lines